### PR TITLE
fix: moduleエラー

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ minecraft {
                     source sourceSets.main
                 }
             }
+            jvmArgs += [
+                    '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+                    '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+            ]
         }
 
         client {
@@ -57,11 +61,17 @@ dependencies {
 
 tasks.named('processResources', ProcessResources).configure {
     var replaceProperties = [
-            minecraft_version: minecraft_version, minecraft_version_range: minecraft_version_range,
-            forge_version: forge_version, forge_version_range: forge_version_range,
-            loader_version_range: loader_version_range,
-            mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
-            mod_authors: mod_authors, mod_description: mod_description,
+            minecraft_version      : minecraft_version,
+            minecraft_version_range: minecraft_version_range,
+            forge_version          : forge_version,
+            forge_version_range    : forge_version_range,
+            loader_version_range   : loader_version_range,
+            mod_id                 : mod_id,
+            mod_name               : mod_name,
+            mod_license            : mod_license,
+            mod_version            : mod_version,
+            mod_authors            : mod_authors,
+            mod_description        : mod_description,
     ]
     inputs.properties replaceProperties
 


### PR DESCRIPTION
## 概要
ForgeはJavaモジュールに非対応
`--add-opens`でパッケージアクセスを許可することで、Javaモジュールを無効化することで対応