### PR TITLE
feature: コードにべた書きした名前で表示

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id 'net.minecraftforge.gradle' version '[6.0,6.2)'
+    id 'org.spongepowered.mixin' version '0.7.+'
 }
 
 version = mod_version
@@ -57,6 +58,12 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+}
+
+mixin {
+    add sourceSets.main, 'mixins.customplayername.refmap.json'
+    config 'mixins.customplayername.json'
 }
 
 tasks.named('processResources', ProcessResources).configure {

--- a/src/main/java/com/sron/customplayername/CustomNameRegistry.java
+++ b/src/main/java/com/sron/customplayername/CustomNameRegistry.java
@@ -3,7 +3,6 @@ package com.sron.customplayername;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import net.minecraft.world.entity.player.Player;
 
 public class CustomNameRegistry {
 
@@ -13,7 +12,7 @@ public class CustomNameRegistry {
     customNames.put(UUID.fromString("380df991-f603-344c-a090-369bad2a924a"), "テストユーザー");
   }
 
-  public static String getNameFor(Player player) {
-    return customNames.getOrDefault(player.getUUID(), player.getName().getString());
+  public static String getNameFor(UUID id, String name) {
+    return customNames.getOrDefault(id, name);
   }
 }

--- a/src/main/java/com/sron/customplayername/CustomNameRegistry.java
+++ b/src/main/java/com/sron/customplayername/CustomNameRegistry.java
@@ -1,0 +1,19 @@
+package com.sron.customplayername;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.world.entity.player.Player;
+
+public class CustomNameRegistry {
+
+  private static final Map<UUID, String> customNames = new HashMap<>();
+
+  static {
+    customNames.put(UUID.fromString("380df991-f603-344c-a090-369bad2a924a"), "テストユーザー");
+  }
+
+  public static String getNameFor(Player player) {
+    return customNames.getOrDefault(player.getUUID(), player.getName().getString());
+  }
+}

--- a/src/main/java/com/sron/customplayername/NameRenderHandler.java
+++ b/src/main/java/com/sron/customplayername/NameRenderHandler.java
@@ -1,5 +1,6 @@
 package com.sron.customplayername;
 
+import java.util.UUID;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
@@ -18,8 +19,10 @@ public class NameRenderHandler {
       return;
     }
 
-    String newName = CustomNameRegistry.getNameFor(player);
-    player.setCustomName(Component.literal(newName));
+    UUID id = player.getUUID();
+    String name = player.getName().getString();
+    String customName = CustomNameRegistry.getNameFor(id, name);
+    player.setCustomName(Component.literal(customName));
     player.setCustomNameVisible(true);
   }
 }

--- a/src/main/java/com/sron/customplayername/NameRenderHandler.java
+++ b/src/main/java/com/sron/customplayername/NameRenderHandler.java
@@ -1,0 +1,23 @@
+package com.sron.customplayername;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderLivingEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = CustomPlayerName.MODID, value = Dist.CLIENT)
+public class NameRenderHandler {
+
+  @SubscribeEvent
+  public static void onRenderName(RenderLivingEvent.Pre<?, ?> event) {
+    if (!(event.getEntity() instanceof Player player)) {
+      return;
+    }
+
+    String newName = CustomNameRegistry.getNameFor(player);
+    player.setCustomName(Component.literal(newName));
+    player.setCustomNameVisible(true);
+  }
+}

--- a/src/main/java/com/sron/customplayername/NameRenderHandler.java
+++ b/src/main/java/com/sron/customplayername/NameRenderHandler.java
@@ -3,10 +3,12 @@ package com.sron.customplayername;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+@OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(modid = CustomPlayerName.MODID, value = Dist.CLIENT)
 public class NameRenderHandler {
 

--- a/src/main/java/com/sron/customplayername/mixin/PlayerDisplayNameMixin.java
+++ b/src/main/java/com/sron/customplayername/mixin/PlayerDisplayNameMixin.java
@@ -1,0 +1,22 @@
+package com.sron.customplayername.mixin;
+
+import com.sron.customplayername.CustomNameRegistry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Player.class)
+public class PlayerDisplayNameMixin {
+
+  @Inject(method = "getDisplayName", at = @At("HEAD"), cancellable = true)
+  public void overrideDisplayName(CallbackInfoReturnable<Component> cir) {
+    Player player = (Player) (Object) this;
+    String customName = CustomNameRegistry.getNameFor(player);
+    if (customName != null) {
+      cir.setReturnValue(Component.literal(customName));
+    }
+  }
+}

--- a/src/main/java/com/sron/customplayername/mixin/PlayerDisplayNameMixin.java
+++ b/src/main/java/com/sron/customplayername/mixin/PlayerDisplayNameMixin.java
@@ -1,6 +1,7 @@
 package com.sron.customplayername.mixin;
 
 import com.sron.customplayername.CustomNameRegistry;
+import java.util.UUID;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,7 +15,9 @@ public class PlayerDisplayNameMixin {
   @Inject(method = "getDisplayName", at = @At("HEAD"), cancellable = true)
   public void overrideDisplayName(CallbackInfoReturnable<Component> cir) {
     Player player = (Player) (Object) this;
-    String customName = CustomNameRegistry.getNameFor(player);
+    UUID id = player.getUUID();
+    String name = player.getName().getString();
+    String customName = CustomNameRegistry.getNameFor(id, name);
     if (customName != null) {
       cir.setReturnValue(Component.literal(customName));
     }

--- a/src/main/java/com/sron/customplayername/mixin/PlayerInfoMixin.java
+++ b/src/main/java/com/sron/customplayername/mixin/PlayerInfoMixin.java
@@ -1,0 +1,27 @@
+package com.sron.customplayername.mixin;
+
+import com.mojang.authlib.GameProfile;
+import com.sron.customplayername.CustomNameRegistry;
+import java.util.UUID;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.minecraft.network.chat.Component;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerInfo.class)
+public class PlayerInfoMixin {
+
+  @Inject(method = "getTabListDisplayName", at = @At("HEAD"), cancellable = true)
+  public void overrideTabListDisplayName(CallbackInfoReturnable<Component> cir) {
+    PlayerInfo self = (PlayerInfo) (Object) this;
+    GameProfile profile = self.getProfile();
+    UUID id = profile.getId();
+    String name = profile.getName();
+    String customName = CustomNameRegistry.getNameFor(id, name);
+    if (customName != null) {
+      cir.setReturnValue(Component.literal(customName));
+    }
+  }
+}

--- a/src/main/resources/mixins.customplayername.json
+++ b/src/main/resources/mixins.customplayername.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.sron.customplayername.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "PlayerDisplayNameMixin"
+  ],
+  "client": [],
+  "server": [],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/mixins.customplayername.json
+++ b/src/main/resources/mixins.customplayername.json
@@ -4,7 +4,8 @@
   "package": "com.sron.customplayername.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "PlayerDisplayNameMixin"
+    "PlayerDisplayNameMixin",
+    "PlayerInfoMixin"
   ],
   "client": [],
   "server": [],


### PR DESCRIPTION
## 概要
以下の箇所でプレイヤー名を置換
- プレイヤー上部に表示されるネームタグ
- チャットの送信者名
- 死亡や実績解除などのシステムログ
- tabキーで開かれるプレイヤーリスト

pキーで開かれるプレイヤーリストについての対応は保留
`PlayerEntry`内で`getPlayerName`を使わず`this.playerName`で取得していて置換が面倒